### PR TITLE
Node v6 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const Serverless = require('serverless')
 const Promise = require('bluebird')
 const { wrap } = require('lambda-wrapper')
 const assert = require('assert')
-const { URL } = require('url')
+const url = require('url')
 const querystring = require('querystring')
 
 class ServerlessInvoker {
@@ -122,7 +122,7 @@ class ServerlessInvoker {
   }
 
   static parseQueryStringParameters (requestUrl) {
-    const myURL = new URL('https://fakehost.com/' + requestUrl.split(' ')[1])
+    const myURL = url.parse('https://fakehost.com/' + requestUrl.split(' ')[1], true)
     const search = myURL.search.length > 0 ? myURL.search.slice(1) : myURL.search
     return querystring.parse(search)
   }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/activescott/serverless-http-invoker.git"
   },
   "scripts": {
-    "test": "clear; ./node_modules/.bin/mocha",
+    "test": "clear; ./node_modules/.bin/mocha --timeout 5000",
     "watch": "clear; ./node_modules/.bin/mocha -w",
     "lint": "./node_modules/.bin/standard './index.js' './test/test.js'",
     "pretest": "npm run lint"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "bdd",
     "tdd"
   ],
+  "engines": { "node": ">=6" },
   "repository": {
     "type": "git",
     "url": "https://github.com/activescott/serverless-http-invoker.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-http-invoker",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Locally invoke Serverless functions via their HTTP event as specified in Serverless.yml for testing.",
   "main": "index.js",
   "author": "scott@willeke.com",


### PR DESCRIPTION
Resolves https://github.com/activescott/serverless-http-invoker/issues/5

Quick fix for supporting node versions v6+.

To test, you can use `nvm install v6.0.0` then `npm test`.
For a more robust solution going forward, we may want to have the tests run in a docker container running node v6.
