### PR TITLE
chore: upgrade github actions/checkout to v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: "Use Node.js (deliberately not using matrix)"
         uses: actions/setup-node@v1
         with:
@@ -71,7 +71,7 @@ jobs:
     needs: finish_tests
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Use Node.js v12.x
         uses: actions/setup-node@v1


### PR DESCRIPTION
closes #95
