### PR TITLE
ensure initializeServerless() runs sequentially

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ class ServerlessInvoker {
     const sls = new Serverless(config)
     // NOTE: I've seen sls.init() run very slowly; nearly 500ms!
     return sls.init().then(() => {
-      sls.service.load().then(() => {
+      return sls.service.load().then(() => {
         sls.service.setFunctionNames({})
         sls.service.mergeArrays()
         sls.service.validate()


### PR DESCRIPTION
fix: ensure initializeServerless() runs sequentially

fixes #126

## What did you implement:

It could happen that `initializeServerless` resolves to early because one then block, which was making async calls did not return a value.

Closes #126

## Todos:

- [ ] Write tests
- [ ] Fix linting errors
- [ ] All tests pass on our CI Server: https://travis-ci.org/activescott/serverless-http-invoker
