### PR TITLE
chore: ignore serverless major version bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
       day: "friday"
     allow:
       - dependency-type: "direct"
+    ignore:
+      - dependency-name: "serverless"
+        update-types: ["version-update:semver-major"]
     commit-message:
       # for production deps, prefix commit messages with "fix" (trigger a patch release)
       prefix: "fix"


### PR DESCRIPTION
## Summary
- Adds `ignore` rule for `serverless` major version updates in dependabot config to prevent automatic PRs upgrading from v3 to v4

## Test plan
- [ ] Verify dependabot no longer proposes serverless v4 bumps on next monthly run