### PR TITLE
feat!: drop Node 14/16/18, require Node.js 20+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [14, 16, 18, 20]
+        node: [20, 22]
 
     steps:
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "tdd"
   ],
   "engines": {
-    "node": ">=14"
+    "node": ">=20"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Drop Node.js 14, 16, and 18 from CI matrix; test against `[20, 22]`
- Bump `engines.node` to `>=20`

## Why
PR #189 (serverless 3.31.0 → 3.40.0) is failing because newer transitive deps — `simple-git` via `@serverless/dashboard-plugin` — emit ES2022 `static {}` class initialization blocks that Node 14 cannot parse. Node 14 has been EOL since April 2023, Node 16 since September 2023, and Node 18 since April 2025. The project README has stated Node.js 20 support for some time (#180), so this aligns the package contract with reality.

This is a breaking change for any consumer still installing on Node <20 — hence the `feat!` / `BREAKING CHANGE:` footer to drive a major version release via semantic-release (0.8.6 → 1.0.0).

## Follow-ups (after merge)
- Update branch protection required checks from `test (18)`, `test (20)` → `test (20)`, `test (22)`.
- `@dependabot recreate` on #189 (and any other red dependabot PRs) to verify the new matrix is green.

## Test plan
- [ ] CI passes on Node 20 and Node 22
- [ ] After merge, semantic-release publishes 1.0.0 to npm
- [ ] After merge + recreate, dependabot PR #189 build is green