### PR TITLE
chore(ci): use Node 24 in publish job for npm 11 OIDC

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,11 +65,8 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
-
-      - name: Update npm
-        run: npm install -g npm@latest
 
       - name: publish to npm
         env:


### PR DESCRIPTION
## Summary
- Switch the publish job from Node 22 → Node 24
- Drop the `npm install -g npm@latest` upgrade step

## Why
The `Update npm` step has been failing in CI with `Cannot find module 'promise-retry'` during the in-place self-upgrade. It was originally added because Node 22 ships with npm 10.9.7, which doesn't support npm trusted publishers (OIDC) — that needs npm ≥11. Node 24 ships with npm ≥11.0.0 out of the box, so we can remove the brittle self-upgrade dance entirely.

This is blocking the 1.0.0 release that #194 should have triggered (tests passed, publish failed).

## Test plan
- [ ] CI passes on the PR
- [ ] After merge, publish job runs to completion and semantic-release publishes 1.0.0