### PR TITLE
chore(ci): ignore serverless v4 via version range in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
       - dependency-type: "direct"
     ignore:
       - dependency-name: "serverless"
-        update-types: ["version-update:semver-major"]
+        versions: [">=4.0.0"]
     commit-message:
       # for production deps, prefix commit messages with "fix" (trigger a patch release)
       prefix: "fix"


### PR DESCRIPTION
## Summary
- `update-types: semver-major` let #202 slip through as a major serverless bump (bundled with an adm-zip removal, so it wasn't a clean single-dependency major)
- Switch to a version-range ignore (`versions: [">=4.0.0"]`), which doesn't depend on dependabot's semver-major classification

## Test plan
- N/A (config only); next scheduled dependabot run should no longer propose serverless v4
- Close #202 manually — bot's `ignore this major version` comment command is unavailable on multi-dependency PRs