### PR TITLE
ci: auto-merge dependabot PRs once checks pass

### DIFF
--- a/.github/workflows/pr-auto-merge-dependabot.yml
+++ b/.github/workflows/pr-auto-merge-dependabot.yml
@@ -1,0 +1,15 @@
+name: Auto-Merge
+on:
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  enable-auto-merge:
+    runs-on: ubuntu-latest
+
+    # Specifically check that dependabot (or another trusted party) created this pull-request, and that it has been labelled correctly.
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependencies')
+    steps:
+      - uses: alexwilson/enable-github-automerge-action@2c32e18a76e0726ffe7a573bfff2d42a20885126 # 3.0.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Summary
- Add auto-merge workflow, mirroring serverless-aws-static-file-handler
- Only fires for dependabot[bot] PRs labeled `dependencies`; enables GitHub's native auto-merge (still gated on required checks `test (20)`/`test (22)`, doesn't bypass CI)
- Pinned to SHA `2c32e18a` = tag `3.0.0` (comment in file notes the mapping so it's easy to bump later)

## Test plan
- Merge, then watch the next dependabot PR to confirm auto-merge gets enabled once labeled and merges after checks pass