### PR TITLE
ci: guard against Serverless Framework v4 upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,9 @@
 version: 2
+# NOTE: The `ignore` and `allow` rules below apply ONLY to Dependabot *version* updates.
+# Dependabot *security* updates ignore both, and will bump "ancestor" dependencies
+# (e.g. serverless v3 -> v4) as needed to fix a vulnerable transitive dependency.
+# The guard-serverless-v3 workflow (a required status check on main) is what actually
+# prevents a serverless v4 upgrade from merging.
 updates:
   # docs v2 https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates
   - package-ecosystem: "npm"

--- a/.github/workflows/guard-serverless-v3.yml
+++ b/.github/workflows/guard-serverless-v3.yml
@@ -29,10 +29,10 @@ jobs:
 
           # Direct dependency ranges in every package.json
           for manifest in $(git ls-files '*package.json'); do
-            for dep_type in dependencies devDependencies; do
+            for dep_type in dependencies devDependencies peerDependencies optionalDependencies; do
               range=$(jq -r --arg t "$dep_type" '.[$t].serverless // empty' "$manifest")
               if [ -n "$range" ]; then
-                major=$(printf '%s' "$range" | grep -o '[0-9]\+' | head -1)
+                major=$(printf '%s' "$range" | grep -o '[0-9]\+' | head -1 || true)
                 if [ "${major:-0}" -ge 4 ]; then
                   echo "::error file=$manifest::serverless \"$range\" found in $manifest — this project is pinned to Serverless Framework v3"
                   failed=1

--- a/.github/workflows/guard-serverless-v3.yml
+++ b/.github/workflows/guard-serverless-v3.yml
@@ -1,0 +1,59 @@
+# Guards against upgrading the Serverless Framework beyond v3.
+# This project is pinned to Serverless Framework v3.
+# Dependabot's ignore rules in .github/dependabot.yml only apply to *version* updates.
+# Dependabot *security* updates ignore both `allow` and `ignore` rules, and will bump
+# "ancestor" dependencies (like serverless) to any version needed to fix a vulnerable
+# transitive dependency. Combined with the dependabot auto-merge workflow, such a PR
+# could merge silently.
+# This check fails whenever serverless v4+ appears in any package.json or package-lock.json,
+# and it is a required status check on main so it blocks auto-merge.
+name: guard-serverless-v3
+on:
+  push:
+    branches: [main, beta, alpha]
+  pull_request:
+    branches: [main, beta, alpha]
+
+jobs:
+  serverless_version_check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: fail if Serverless Framework v4+ is present
+        run: |
+          set -euo pipefail
+          failed=0
+
+          # Direct dependency ranges in every package.json
+          for manifest in $(git ls-files '*package.json'); do
+            for dep_type in dependencies devDependencies; do
+              range=$(jq -r --arg t "$dep_type" '.[$t].serverless // empty' "$manifest")
+              if [ -n "$range" ]; then
+                major=$(printf '%s' "$range" | grep -o '[0-9]\+' | head -1)
+                if [ "${major:-0}" -ge 4 ]; then
+                  echo "::error file=$manifest::serverless \"$range\" found in $manifest — this project is pinned to Serverless Framework v3"
+                  failed=1
+                fi
+              fi
+            done
+          done
+
+          # Resolved versions in every package-lock.json
+          for lockfile in $(git ls-files '*package-lock.json'); do
+            version=$(jq -r '.packages["node_modules/serverless"].version // empty' "$lockfile")
+            if [ -n "$version" ]; then
+              major=${version%%.*}
+              if [ "$major" -ge 4 ]; then
+                echo "::error file=$lockfile::serverless resolved to $version in $lockfile — this project is pinned to Serverless Framework v3"
+                failed=1
+              fi
+            fi
+          done
+
+          if [ "$failed" -eq 0 ]; then
+            echo "OK: no Serverless Framework v4+ found in any manifest or lockfile"
+          fi
+          exit "$failed"


### PR DESCRIPTION
## Why

Dependabot `ignore`/`allow` rules in `dependabot.yml` apply only to Dependabot **version** updates. Dependabot **security** updates ignore both, and will bump "ancestor" dependencies (like `serverless`) to whatever version fixes a vulnerable transitive dependency — as happened in activescott/serverless-aws-static-file-handler#434 (serverless 3.35.2 → 4.39.0). With auto-merge enabled for dependabot PRs (merged earlier in 0990243), such an upgrade could merge silently.

## What

- `guard-serverless-v3` workflow: fails when Serverless Framework v4+ appears as a dependency range in any `package.json` or as the resolved version in any `package-lock.json`. The job (`serverless_version_check`) is added to the required status checks on `main`, so it blocks auto-merge of any PR that upgrades serverless past v3.
- Comment in `dependabot.yml` documenting that its ignore rules do not cover security updates.

See also activescott/serverless-aws-static-file-handler#435 (same guard there).